### PR TITLE
Use config instead of credentials as a field and specify 'es' as the service for this request

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,20 @@ const AWS = require('aws-sdk');
 class AmazonConnection extends Connection {
   constructor (options) {
     super(options);
+    this.awsConfig = options.awsConfig || AWS.config;
+  }
 
-    this.config = options.awsConfig || AWS.config;
+  get credentials () {
+    return {
+      accessKeyId: this.awsConfig.credentials.accessKeyId || process.env.AWS_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY,
+      secretAccessKey: this.awsConfig.credentials.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY || process.env.AWS_SECRET_KEY,
+      sessionToken: this.awsConfig.credentials.sessionToken || process.env.AWS_SESSION_TOKEN
+    };
   }
 
   buildRequestObject (params) {
     const req = super.buildRequestObject(params);
+
     if (!req.headers) {
       req.headers = {};
     }
@@ -26,14 +34,7 @@ class AmazonConnection extends Connection {
       req.headers['Content-Length'] = 0;
     }
 
-    req.service = 'es';
-    const credentials = {
-      accessKeyId: this.config.credentials.accessKeyId || process.env.AWS_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY,
-      secretAccessKey: this.config.credentials.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY || process.env.AWS_SECRET_KEY,
-      sessionToken: this.config.credentials.sessionToken || process.env.AWS_SESSION_TOKEN
-    };
-
-    return aws4.sign(req, credentials);
+    return aws4.sign(req, this.credentials);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,18 +6,11 @@ class AmazonConnection extends Connection {
   constructor (options) {
     super(options);
 
-    const awsConfig = options.awsConfig || AWS.config;
-
-    this.credentials = {
-      accessKeyId: awsConfig.credentials.accessKeyId || process.env.AWS_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY,
-      secretAccessKey: awsConfig.credentials.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY || process.env.AWS_SECRET_KEY,
-      sessionToken: awsConfig.credentials.sessionToken || process.env.AWS_SESSION_TOKEN
-    };
+    this.config = options.awsConfig || AWS.config;
   }
 
   buildRequestObject (params) {
     const req = super.buildRequestObject(params);
-
     if (!req.headers) {
       req.headers = {};
     }
@@ -33,7 +26,14 @@ class AmazonConnection extends Connection {
       req.headers['Content-Length'] = 0;
     }
 
-    return aws4.sign(req, this.credentials);
+    req.service = 'es';
+    const credentials = {
+      accessKeyId: this.config.credentials.accessKeyId || process.env.AWS_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY,
+      secretAccessKey: this.config.credentials.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY || process.env.AWS_SECRET_KEY,
+      sessionToken: this.config.credentials.sessionToken || process.env.AWS_SESSION_TOKEN
+    };
+
+    return aws4.sign(req, credentials);
   }
 }
 


### PR DESCRIPTION
`AWS.config.credentials` might expire as described in the docs https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Credentials.html
This implies that a long-running application won't be able to use the refreshed keys and token.
By fetching them right before signing the request might prevent requests with old keys/token to fail.