### PR TITLE
Change AmazonConnection to be a factory to support static credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,13 @@ const { AmazonConnection } = require('aws-elasticsearch-connector');
 
 const client = new Client({
   node: 'my-elasticsearch-cluster.us-east-1.es.amazonaws.com',
-  Connection: AmazonConnection,
-  awsConfig: {
+  Connection: AmazonConnection({
     credentials: {
       accessKeyId: 'foo',
       secretAccessKey: 'bar',
       sessionToken: 'baz' // optional
     }
-  }
+  })
 });
 ```
 
@@ -51,7 +50,7 @@ AWS.config.update({
 
 const client = new Client({
   node: 'my-elasticsearch-cluster.us-east-1.es.amazonaws.com',
-  Connection: AmazonConnection
+  Connection: AmazonConnection()
 });
 ```
 
@@ -69,7 +68,7 @@ const { AmazonConnection } = require('aws-elasticsearch-connector');
 
 const client = new Client({
   node: 'my-elasticsearch-cluster.us-east-1.es.amazonaws.com',
-  Connection: AmazonConnection,
+  Connection: AmazonConnection(),
 });
 ```
 
@@ -86,7 +85,7 @@ const { AmazonConnection, AmazonTransport } = require('aws-elasticsearch-connect
 
 const client = new Client({
   node: 'my-elasticsearch-cluster.us-east-1.es.amazonaws.com',
-  Connection: AmazonConnection,
+  Connection: AmazonConnection(),
   Transport: AmazonTransport
 });
 ```

--- a/src/AmazonConnection.js
+++ b/src/AmazonConnection.js
@@ -3,46 +3,49 @@ const aws4 = require('aws4')
 const AWS = require('aws-sdk')
 const get = require('lodash.get')
 
-class AmazonConnection extends Connection {
-  constructor (options) {
-    super(options)
-    this.awsConfig = options.awsConfig || AWS.config
+
+module.exports = (awsConfig) => {
+  class AmazonConnection extends Connection {
+    constructor (options) {
+      super(options)
+      this.awsConfig = awsConfig || AWS.config
+    }
+
+    get credentials () {
+      const credentials = {
+        accessKeyId: get(this.awsConfig, 'credentials.accessKeyId', process.env.AWS_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY || false),
+        secretAccessKey: get(this.awsConfig, 'credentials.secretAccessKey', process.env.AWS_SECRET_ACCESS_KEY || process.env.AWS_SECRET_KEY || false),
+        sessionToken: get(this.awsConfig, 'credentials.sessionToken', process.env.AWS_SESSION_TOKEN)
+      }
+
+      if (!credentials.accessKeyId || !credentials.secretAccessKey) {
+        throw new Error('Missing AWS credentials')
+      }
+
+      return credentials
+    }
+
+    buildRequestObject (params) {
+      const req = super.buildRequestObject(params)
+
+      if (!req.headers) {
+        req.headers = {}
+      }
+
+      // Fix the Host header, since HttpConnector.makeReqParams() appends
+      // the port number which will cause signature verification to fail
+      req.headers.Host = req.hostname
+
+      if (params.body) {
+        req.headers['Content-Length'] = Buffer.byteLength(params.body, 'utf8')
+        req.body = params.body
+      } else {
+        req.headers['Content-Length'] = 0
+      }
+
+      return aws4.sign(req, this.credentials)
+    }
   }
 
-  get credentials () {
-    const credentials = {
-      accessKeyId: get(this.awsConfig, 'credentials.accessKeyId', process.env.AWS_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY || false),
-      secretAccessKey: get(this.awsConfig, 'credentials.secretAccessKey', process.env.AWS_SECRET_ACCESS_KEY || process.env.AWS_SECRET_KEY || false),
-      sessionToken: get(this.awsConfig, 'credentials.sessionToken', process.env.AWS_SESSION_TOKEN)
-    }
-
-    if (!credentials.accessKeyId || !credentials.secretAccessKey) {
-      throw new Error('Missing AWS credentials')
-    }
-
-    return credentials
-  }
-
-  buildRequestObject (params) {
-    const req = super.buildRequestObject(params)
-
-    if (!req.headers) {
-      req.headers = {}
-    }
-
-    // Fix the Host header, since HttpConnector.makeReqParams() appends
-    // the port number which will cause signature verification to fail
-    req.headers.Host = req.hostname
-
-    if (params.body) {
-      req.headers['Content-Length'] = Buffer.byteLength(params.body, 'utf8')
-      req.body = params.body
-    } else {
-      req.headers['Content-Length'] = 0
-    }
-
-    return aws4.sign(req, this.credentials)
-  }
+  return AmazonConnection
 }
-
-module.exports = AmazonConnection


### PR DESCRIPTION
Hi there! Thanks for creating this for us to use! 

We use a different set of AWS IAM credentials for elastic search, but when we followed your static credentials instructions, we found that the elasticsearch-js client does not properly pass in the `awsConfig` options when creating the connection pool. 

In order to provide custom AWS credentials, I changed your `AmazonConnection.js` into a factory, which will return the `AmazonConnection` class after applying the  credentials that are passed in. This was the least invasive way I can think of to remediate the issue. 

Please let me know if you have any other suggestions/input.