### PR TITLE
Specify service is 'es'

### DIFF
--- a/src/AmazonConnection.js
+++ b/src/AmazonConnection.js
@@ -25,6 +25,7 @@ class AmazonConnection extends Connection {
 
   buildRequestObject (params) {
     const req = super.buildRequestObject(params)
+    req.service = 'es'
 
     if (!req.headers) {
       req.headers = {}


### PR DESCRIPTION
Thank you for your great work. I'm happy to use your code.

I got an ResponseError that says `message: 'Credential should be scoped to correct service: \'es\'` while trying to use it.

By looking at https://github.com/mhart/aws4 , I think I need to add `req.service = 'es'` to the code.
If my idea has any problem, or there is another better way, please feel free to correct it.