### PR TITLE
Headers cause Error: Signature not matching

### DIFF
--- a/src/AmazonConnection.js
+++ b/src/AmazonConnection.js
@@ -32,13 +32,13 @@ class AmazonConnection extends Connection {
 
     // Fix the Host header, since HttpConnector.makeReqParams() appends
     // the port number which will cause signature verification to fail
-    req.headers.Host = req.hostname
+    req.headers.host = req.hostname
 
     if (params.body) {
-      req.headers['Content-Length'] = Buffer.byteLength(params.body, 'utf8')
+      req.headers['content-length'] = Buffer.byteLength(params.body, 'utf8')
       req.body = params.body
     } else {
-      req.headers['Content-Length'] = 0
+      req.headers['content-length'] = 0
     }
 
     return aws4.sign(req, this.credentials)

--- a/tests/AmazonConnection.test.js
+++ b/tests/AmazonConnection.test.js
@@ -142,10 +142,10 @@ describe('AmazonConnection', function () {
         headers: {}
       })
 
-      assert.strictEqual(req.headers.Host, 'foo.us-east-1.es.amazonaws.com')
+      assert.strictEqual(req.headers.host, 'foo.us-east-1.es.amazonaws.com')
     })
 
-    it('sets the Content-Length: 0 header when there is no body', function () {
+    it('sets the content-length: 0 header when there is no body', function () {
       const req = connector.buildRequestObject({
         method: 'POST',
         path: '/_cluster/health',
@@ -154,10 +154,10 @@ describe('AmazonConnection', function () {
         headers: {}
       })
 
-      assert.strictEqual(req.headers['Content-Length'], 0)
+      assert.strictEqual(req.headers['content-length'], 0)
     })
 
-    it('sets the Content-Length header when there is a body', function () {
+    it('sets the content-length header when there is a body', function () {
       const req = connector.buildRequestObject({
         method: 'POST',
         path: '/_cluster/health',
@@ -166,7 +166,7 @@ describe('AmazonConnection', function () {
         headers: {}
       })
 
-      assert.strictEqual(req.headers['Content-Length'], 3)
+      assert.strictEqual(req.headers['content-length'], 3)
       assert.strictEqual(req.body, 'foo')
     })
 


### PR DESCRIPTION
Since yesterday I was getting this error from aws:
"The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details."
By changing the headers from uppercase to lowercase I managed to make it work again.