### PR TITLE
Support for 7.7.0 and up

### DIFF
--- a/src/AmazonTransport.js
+++ b/src/AmazonTransport.js
@@ -20,7 +20,7 @@ class AmazonTransport extends Transport {
     // Promise support
     if (callback == null) {
       return this.awaitAwsCredentials()
-        .then(() => super.request(params, options, null))
+        .then(() => super.request(params, options))
     }
 
     // Callback support


### PR DESCRIPTION
This commit https://github.com/elastic/elasticsearch-js/commit/27a8e2a9bf614224a96bf44293ace8a112ec8677#diff-d6fe90f49afb1b1df87ae8d285a4f1df is breaking aws-elasticsearch-connector from 7.7.0 and up