### PR TITLE
Authentication fails on get requests #17

### DIFF
--- a/src/AmazonConnection.js
+++ b/src/AmazonConnection.js
@@ -14,7 +14,7 @@ module.exports = awsConfig => {
 
       // Fix the Host header, since HttpConnector.makeReqParams() appends
       // the port number which will cause signature verification to fail
-      req.headers.host = req.hostname
+      req.headers.Host = req.hostname
 
       if (params.body) {
         req.headers['content-length'] = Buffer.byteLength(params.body, 'utf8')

--- a/src/AmazonConnection.js
+++ b/src/AmazonConnection.js
@@ -14,7 +14,10 @@ module.exports = awsConfig => {
 
       // Fix the Host header, since HttpConnector.makeReqParams() appends
       // the port number which will cause signature verification to fail
-      req.headers.Host = req.hostname
+      req.headers.host = req.hostname
+      if(req.headers.Host) {
+        delete req.headers.Host;
+      }
 
       if (params.body) {
         req.headers['content-length'] = Buffer.byteLength(params.body, 'utf8')

--- a/tests/AmazonConnection.test.js
+++ b/tests/AmazonConnection.test.js
@@ -32,7 +32,7 @@ describe('AmazonConnection', function () {
         headers: {}
       })
 
-      assert.strictEqual(req.headers.host, 'foo.us-east-1.es.amazonaws.com')
+      assert.strictEqual(req.headers.Host, 'foo.us-east-1.es.amazonaws.com')
     })
 
     it('sets the content-length: 0 header when there is no body', function () {

--- a/tests/AmazonConnection.test.js
+++ b/tests/AmazonConnection.test.js
@@ -32,7 +32,7 @@ describe('AmazonConnection', function () {
         headers: {}
       })
 
-      assert.strictEqual(req.headers.Host, 'foo.us-east-1.es.amazonaws.com')
+      assert.strictEqual(req.headers.host, 'foo.us-east-1.es.amazonaws.com')
     })
 
     it('sets the content-length: 0 header when there is no body', function () {


### PR DESCRIPTION
This fixes the signing header for elastic search requests, as the lowercase "host" header causes header size issues and invalidates the signing.