### PR TITLE
Add support for elasticSearch 6.x branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "aws4": "^1.10.0"
   },
   "peerDependencies": {
-    "@elastic/elasticsearch": ">=7.8.0",
+    "@elastic/elasticsearch": ">=6.8.8",
     "aws-sdk": "^2.709.0"
   },
   "devDependencies": {

--- a/src/AmazonConnection.js
+++ b/src/AmazonConnection.js
@@ -16,11 +16,16 @@ module.exports = awsConfig => {
       // the port number which will cause signature verification to fail
       req.headers.host = req.hostname
 
+      let contentLength = 0
       if (params.body) {
-        req.headers['content-length'] = Buffer.byteLength(params.body, 'utf8')
+        contentLength = Buffer.byteLength(params.body, 'utf8')
         req.body = params.body
-      } else {
-        req.headers['content-length'] = 0
+      }
+      const lengthHeader = 'content-length'
+      const headerFound = Object.keys(req.headers).find(
+        header => header.toLowerCase() === lengthHeader)
+      if (headerFound === undefined) {
+        req.headers[lengthHeader] = contentLength
       }
 
       return aws4.sign(req, awsConfig.credentials)


### PR DESCRIPTION
This fix allows the connector to work with the older 6.x elastic branch. The problem with that version, is that the Transport object, would add a "Content-Length" header (yes with Pascal Case), thus making it send 2 headers: Content-Length, and content-length, which makes the signature fail.