### PR TITLE
AWS SDK v3 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ async function assumeRole(roleArn, region) {
     sessionToken: response.Credentials.SessionToken,
   };
 }
-
-ping();
 ```
 
 ## Test

--- a/README.md
+++ b/README.md
@@ -21,38 +21,79 @@ npm install --save aws-elasticsearch-connector @elastic/elasticsearch aws-sdk
 ### Using global configuration
 
 ```javascript
-const { Client } = require('@elastic/elasticsearch')
-const AWS = require('aws-sdk')
-const createAwsElasticsearchConnector = require('aws-elasticsearch-connector')
+const { Client } = require("@elastic/elasticsearch");
+const AWS = require("aws-sdk");
+const createAwsElasticsearchConnector = require("aws-elasticsearch-connector");
 
 // (Optional) load profile credentials from file
 AWS.config.update({
-  profile: 'my-profile'
-})
+  profile: "my-profile",
+});
 
 const client = new Client({
   ...createAwsElasticsearchConnector(AWS.config),
-  node: 'https://my-elasticsearch-cluster.us-east-1.es.amazonaws.com'
-})
+  node: "https://my-elasticsearch-cluster.us-east-1.es.amazonaws.com",
+});
 ```
 
 ### Using specific configuration
 
 ```javascript
-const { Client } = require('@elastic/elasticsearch')
-const AWS = require('aws-sdk')
-const createAwsElasticsearchConnector = require('aws-elasticsearch-connector')
+const { Client } = require("@elastic/elasticsearch");
+const AWS = require("aws-sdk");
+const createAwsElasticsearchConnector = require("aws-elasticsearch-connector");
 
 const awsConfig = new AWS.Config({
   // Your credentials and settings here, see
   // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#constructor-property
-})
+});
 
 const client = new Client({
   ...createAwsElasticsearchConnector(awsConfig),
-  node: 'https://my-elasticsearch-cluster.us-east-1.es.amazonaws.com'
-})
-````
+  node: "https://my-elasticsearch-cluster.us-east-1.es.amazonaws.com",
+});
+```
+
+### Using aws-sdk v3
+
+```javascript
+const { STSClient, AssumeRoleCommand } = require("@aws-sdk/client-sts");
+const { Client } = require("@elastic/elasticsearch");
+const createAwsElasticsearchConnector = require("./src/index.js");
+
+async function ping() {
+  const creds = await assumeRole(
+    "arn:aws:iam::062437324875:role/Administrator",
+    "us-east-1"
+  );
+  const client = new Client({
+    ...createAwsElasticsearchConnector({
+      region: "us-east-1",
+      credentials: creds,
+    }),
+    node: "https://my-elasticsearch-cluster.us-east-1.es.amazonaws.com",
+  });
+  const response = await client.ping();
+  console.log(`Got Response`, response);
+}
+
+async function assumeRole(roleArn, region) {
+  const client = new STSClient({ region });
+  const response = await client.send(
+    new AssumeRoleCommand({
+      RoleArn: roleArn,
+      RoleSessionName: "aws-es-connection",
+    })
+  );
+  return {
+    accessKeyId: response.Credentials.AccessKeyId,
+    secretAccessKey: response.Credentials.SecretAccessKey,
+    sessionToken: response.Credentials.SessionToken,
+  };
+}
+
+ping();
+```
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ const createAwsElasticsearchConnector = require("./src/index.js");
 
 async function ping() {
   const creds = await assumeRole(
-    "arn:aws:iam::062437324875:role/Administrator",
+    "arn:aws:iam::0123456789012:role/Administrator",
     "us-east-1"
   );
   const client = new Client({

--- a/src/AmazonTransport.js
+++ b/src/AmazonTransport.js
@@ -1,6 +1,6 @@
 const { Transport } = require('@elastic/elasticsearch')
 
-function awaitAwsCredentials (awsConfig) {
+function awaitAwsCredentials(awsConfig) {
   return new Promise((resolve, reject) => {
     awsConfig.getCredentials((err) => {
       err ? reject(err) : resolve()
@@ -10,24 +10,34 @@ function awaitAwsCredentials (awsConfig) {
 
 module.exports = awsConfig => {
   class AmazonTransport extends Transport {
-    request (params, options = {}, callback = undefined) {
+    request(params, options = {}, callback = undefined) {
       // options is optional, so if it is omitted, options will be the callback
       if (typeof options === 'function') {
         callback = options
         options = {}
       }
 
-      // Promise support
-      if (typeof callback === 'undefined') {
-        return awaitAwsCredentials(awsConfig)
-          .then(() => super.request(params, options))
-      }
+      // check if getCredentials exists, if so this is an aws-sdk v2 global config object
+      if (typeof awsConfig.getCredentials !== 'function') {
+        if (typeof callback === 'undefined') {
+          return super.request(params, options);
+        } else {
+          super.request(params, options, callback);
+        }
+      } else {
+        // Promise support
+        if (typeof callback === 'undefined') {
+          return awaitAwsCredentials(awsConfig)
+            .then(() => super.request(params, options))
+        }
 
-      // Callback support
-      awaitAwsCredentials(awsConfig)
-        .then(() => super.request(params, options, callback))
-        .catch(callback)
+        // Callback support
+        awaitAwsCredentials(awsConfig)
+          .then(() => super.request(params, options, callback))
+          .catch(callback)
+      }
     }
+
   }
 
   return AmazonTransport

--- a/src/AmazonTransport.js
+++ b/src/AmazonTransport.js
@@ -1,6 +1,6 @@
 const { Transport } = require('@elastic/elasticsearch')
 
-function awaitAwsCredentials(awsConfig) {
+function awaitAwsCredentials (awsConfig) {
   return new Promise((resolve, reject) => {
     awsConfig.getCredentials((err) => {
       err ? reject(err) : resolve()
@@ -10,7 +10,7 @@ function awaitAwsCredentials(awsConfig) {
 
 module.exports = awsConfig => {
   class AmazonTransport extends Transport {
-    request(params, options = {}, callback = undefined) {
+    request (params, options = {}, callback = undefined) {
       // options is optional, so if it is omitted, options will be the callback
       if (typeof options === 'function') {
         callback = options
@@ -20,9 +20,9 @@ module.exports = awsConfig => {
       // check if getCredentials exists, if so this is an aws-sdk v2 global config object
       if (typeof awsConfig.getCredentials !== 'function') {
         if (typeof callback === 'undefined') {
-          return super.request(params, options);
+          return super.request(params, options)
         } else {
-          super.request(params, options, callback);
+          super.request(params, options, callback)
         }
       } else {
         // Promise support
@@ -37,7 +37,6 @@ module.exports = awsConfig => {
           .catch(callback)
       }
     }
-
   }
 
   return AmazonTransport


### PR DESCRIPTION
Addresses #32 and #33 

Adds a little bit of logic to support both the aws-sdk v2 global configuration model, and allow for use within the aws-sdk v3 which no longer uses global configuration.

Implementors using the aw-sdk v3 can simply pass `region` and a `credentials` object directly in place of the global `awsConfig`.

Added an example using the `@aws-sdk/client-sts` to the documentation, `aws4` wants the `secretAccessKey`, `accessKeyId` and `sessionToken` in `camelCase`, but all the aws-sdk v3 clients provide them in `PascalCase`, so you need to convert the properties around first.